### PR TITLE
Feat/#502/견적 요청 삭제 스케줄러

### DIFF
--- a/src/main/java/com/beautymeongdang/domain/quote/repository/DirectQuoteRequestRepository.java
+++ b/src/main/java/com/beautymeongdang/domain/quote/repository/DirectQuoteRequestRepository.java
@@ -19,6 +19,6 @@ public interface DirectQuoteRequestRepository extends JpaRepository<DirectQuoteR
 
 
     // qoute Request 물리적 삭제 스케줄러
-    void deleteByDirectQuoteRequestId_RequestId(QuoteRequest requestId);
+    void deleteByDirectQuoteRequestIdAndRequestId(QuoteRequest requestId);
 
 }

--- a/src/main/java/com/beautymeongdang/domain/quote/repository/DirectQuoteRequestRepository.java
+++ b/src/main/java/com/beautymeongdang/domain/quote/repository/DirectQuoteRequestRepository.java
@@ -16,4 +16,9 @@ public interface DirectQuoteRequestRepository extends JpaRepository<DirectQuoteR
     // 특정 견적 요청서에 해당하는 DirectQuoteRequest 조회
     @Query("SELECT d FROM DirectQuoteRequest d WHERE d.directQuoteRequestId.requestId = :quoteRequest")
     Optional<DirectQuoteRequest> findByQuoteRequest(@Param("quoteRequest") QuoteRequest quoteRequest);
+
+
+    // qoute Request 물리적 삭제 스케줄러
+    void deleteByDirectQuoteRequestId_RequestId(QuoteRequest requestId);
+
 }

--- a/src/main/java/com/beautymeongdang/domain/quote/repository/QuoteRequestImageRepository.java
+++ b/src/main/java/com/beautymeongdang/domain/quote/repository/QuoteRequestImageRepository.java
@@ -1,5 +1,6 @@
 package com.beautymeongdang.domain.quote.repository;
 
+import com.beautymeongdang.domain.quote.entity.QuoteRequest;
 import com.beautymeongdang.domain.quote.entity.QuoteRequestImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,9 @@ public interface QuoteRequestImageRepository extends JpaRepository<QuoteRequestI
     @Query("SELECT qri FROM QuoteRequestImage qri " +
            "WHERE qri.requestId.requestId = :requestId")
     List<QuoteRequestImage> findAllByRequestId(@Param("requestId") Long requestId);
+
+    // qoute Request 물리적 삭제 스케줄러
+    List<QuoteRequestImage> findAllByRequestId(QuoteRequest requestId);
+
+
 }

--- a/src/main/java/com/beautymeongdang/domain/quote/repository/QuoteRequestRepository.java
+++ b/src/main/java/com/beautymeongdang/domain/quote/repository/QuoteRequestRepository.java
@@ -260,5 +260,5 @@ public interface QuoteRequestRepository extends JpaRepository<QuoteRequest, Long
     WHERE qr.isDeleted = true
       AND qr.updatedAt < :deleteDay
     """)
-    List<QuoteRequest> findAllByIsDeletedAndAndUpdatedAt(@Param("deleteDay") LocalDateTime deleteDay);
+    List<QuoteRequest> findAllByIsDeletedAndUpdatedAt(@Param("deleteDay") LocalDateTime deleteDay);
 }

--- a/src/main/java/com/beautymeongdang/domain/quote/repository/QuoteRequestRepository.java
+++ b/src/main/java/com/beautymeongdang/domain/quote/repository/QuoteRequestRepository.java
@@ -252,4 +252,13 @@ public interface QuoteRequestRepository extends JpaRepository<QuoteRequest, Long
 
     // 반려견 프로필 논리적 삭제
     List<QuoteRequest> findAllByDogId(Dog dog);
+
+    // qoute Request 물리적 삭제 스케줄러
+    @Query("""
+    SELECT qr
+    FROM QuoteRequest qr
+    WHERE qr.isDeleted = true
+      AND qr.updatedAt < :deleteDay
+    """)
+    List<QuoteRequest> findAllByIsDeletedAndAndUpdatedAt(@Param("deleteDay") LocalDateTime deleteDay);
 }

--- a/src/main/java/com/beautymeongdang/domain/quote/repository/TotalQuoteRequestRepository.java
+++ b/src/main/java/com/beautymeongdang/domain/quote/repository/TotalQuoteRequestRepository.java
@@ -15,4 +15,9 @@ public interface TotalQuoteRequestRepository extends JpaRepository<TotalQuoteReq
 
     // 고객(자신)이 보낸 견적 요청 상세 조회
     TotalQuoteRequest findByRequestId(QuoteRequest requestId);
+
+
+    // qoute Request 물리적 삭제 스케줄러
+    void deleteByRequestId(QuoteRequest requestId);
+
 }

--- a/src/main/java/com/beautymeongdang/global/common/scheduler/chat/ChatScheduledService.java
+++ b/src/main/java/com/beautymeongdang/global/common/scheduler/chat/ChatScheduledService.java
@@ -6,6 +6,7 @@ import com.beautymeongdang.domain.chat.entity.ChatMessageImage;
 import com.beautymeongdang.domain.chat.repository.ChatMessageImageRepository;
 import com.beautymeongdang.domain.chat.repository.ChatMessageRepository;
 import com.beautymeongdang.domain.chat.repository.ChatRepository;
+import com.beautymeongdang.infra.s3.FileStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ public class ChatScheduledService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatMessageImageRepository chatMessageImageRepository;
     private final ChatRepository chatRepository;
+    private final FileStore fileStore;
 
     // 채팅 메시지 물리적 삭제 스케줄러
     @Scheduled(cron = "0 0 1 * * *")
@@ -42,21 +44,18 @@ public class ChatScheduledService {
     @Scheduled(cron = "0 0 1 * * *")
     @Transactional
     public void deleteDeletedChats() {
-        // 30일 전에 논리적으로 삭제된 채팅방 찾기
         List<Chat> deletedChats = chatRepository.findAllByDeletedAndUpdatedAt(LocalDateTime.now().minusDays(30));
 
         deletedChats.forEach(chat -> {
             List<ChatMessage> chatMessages = chatMessageRepository.findAllByChatId(chat);
             chatMessages.forEach(chatMessage -> {
-                // 각 채팅 메시지에 관련된 이미지 삭제
                 List<ChatMessageImage> chatMessageImages = chatMessageImageRepository.findAllByMessageId(chatMessage);
+                chatMessageImages.forEach(image -> fileStore.deleteFile(image.getImageUrl()));
                 chatMessageImageRepository.deleteAll(chatMessageImages);
 
-                // 채팅 메시지 삭제
                 chatMessageRepository.delete(chatMessage);
             });
 
-            // 채팅방 삭제
             chatRepository.delete(chat);
         });
     }

--- a/src/main/java/com/beautymeongdang/global/common/scheduler/dog/DogScheduledService.java
+++ b/src/main/java/com/beautymeongdang/global/common/scheduler/dog/DogScheduledService.java
@@ -18,6 +18,8 @@ public class DogScheduledService {
 
     private final DogRepository dogRepository;
     private final FileStore fileStore;
+    private static final String DEFAULT_DOG_PROFILE_IMAGE = "https://s3-beauty-meongdang.s3.ap-northeast-2.amazonaws.com/%EB%B0%98%EB%A0%A7%EA%B2%AC+%ED%94%84%EB%A1%9C%ED%95%84+%EC%9D%B4%EB%AF%B8%EC%A7%80/%EB%B0%98%EB%A0%A7%EA%B2%AC%ED%94%84%EB%A1%9C%ED%95%84%EA%B8%B0%EB%B3%B8%EC%9D%B4%EB%AF%B8%EC%A7%80.jpg";
+
 
     // 반려견 물리적 삭제 스케줄러
     @Scheduled(cron = "0 0 1 * * *")
@@ -26,7 +28,7 @@ public class DogScheduledService {
         List<Dog> dogs = dogRepository.findAllByIsDeletedAndUpdatedAt(LocalDateTime.now().minusDays(30));
 
         dogs.forEach(dog -> {
-            if (dog.getProfileImage() != null) {
+            if (dog.getProfileImage() != null && !dog.getProfileImage().equals(DEFAULT_DOG_PROFILE_IMAGE)) {
                 fileStore.deleteFile(dog.getProfileImage());
             }
             dogRepository.delete(dog);

--- a/src/main/java/com/beautymeongdang/global/common/scheduler/quote/QuoteRequestScheduledService.java
+++ b/src/main/java/com/beautymeongdang/global/common/scheduler/quote/QuoteRequestScheduledService.java
@@ -29,7 +29,7 @@ public class  QuoteRequestScheduledService {
     @Scheduled(cron = "0 0 1 * * *")
     @Transactional
     public void deleteQuoteRequest() {
-        List<QuoteRequest> quoteRequests = quoteRequestRepository.findAllByIsDeletedAndAndUpdatedAt(LocalDateTime.now().minusDays(30));
+        List<QuoteRequest> quoteRequests = quoteRequestRepository.findAllByIsDeletedAndUpdatedAt(LocalDateTime.now().minusDays(30));
 
         quoteRequests.forEach(quoteRequest -> {
             // 견적 요청 이미지 삭제
@@ -41,7 +41,7 @@ public class  QuoteRequestScheduledService {
             totalQuoteRequestRepository.deleteByRequestId(quoteRequest);
 
             // 1:1 견적 요청 삭제
-            directQuoteRequestRepository.deleteByDirectQuoteRequestId_RequestId(quoteRequest);
+            directQuoteRequestRepository.deleteByDirectQuoteRequestIdAndRequestId(quoteRequest);
 
             // 견적 요청 삭제
             quoteRequestRepository.delete(quoteRequest);

--- a/src/main/java/com/beautymeongdang/global/common/scheduler/quote/QuoteRequestScheduledService.java
+++ b/src/main/java/com/beautymeongdang/global/common/scheduler/quote/QuoteRequestScheduledService.java
@@ -1,0 +1,50 @@
+package com.beautymeongdang.global.common.scheduler.quote;
+
+import com.beautymeongdang.domain.quote.entity.QuoteRequest;
+import com.beautymeongdang.domain.quote.entity.QuoteRequestImage;
+import com.beautymeongdang.domain.quote.repository.DirectQuoteRequestRepository;
+import com.beautymeongdang.domain.quote.repository.QuoteRequestImageRepository;
+import com.beautymeongdang.domain.quote.repository.QuoteRequestRepository;
+import com.beautymeongdang.domain.quote.repository.TotalQuoteRequestRepository;
+import com.beautymeongdang.infra.s3.FileStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class  QuoteRequestScheduledService {
+    private final QuoteRequestRepository quoteRequestRepository;
+    private final QuoteRequestImageRepository quoteRequestImageRepository;
+    private final TotalQuoteRequestRepository totalQuoteRequestRepository;
+    private final DirectQuoteRequestRepository directQuoteRequestRepository;
+    private final FileStore fileStore;
+
+
+    @Scheduled(cron = "0 0 1 * * *")
+    @Transactional
+    public void deleteQuoteRequest() {
+        List<QuoteRequest> quoteRequests = quoteRequestRepository.findAllByIsDeletedAndAndUpdatedAt(LocalDateTime.now().minusDays(30));
+
+        quoteRequests.forEach(quoteRequest -> {
+            // 견적 요청 이미지 삭제
+            List<QuoteRequestImage> images = quoteRequestImageRepository.findAllByRequestId(quoteRequest);
+            images.forEach(image -> fileStore.deleteFile(image.getImageUrl()));
+            quoteRequestImageRepository.deleteAll(images);
+
+            // 전체 견적 요청 삭제
+            totalQuoteRequestRepository.deleteByRequestId(quoteRequest);
+
+            // 1:1 견적 요청 삭제
+            directQuoteRequestRepository.deleteByDirectQuoteRequestId_RequestId(quoteRequest);
+
+            // 견적 요청 삭제
+            quoteRequestRepository.delete(quoteRequest);
+        });
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- `DirectQuoteRequestRepository`에 특정 `QuoteRequest` 식별자로 `DirectQuoteRequest`를 삭제하는 메소드 추가.
	- `QuoteRequestImageRepository`에 `QuoteRequest` 객체를 기반으로 이미지를 조회하는 메소드 추가.
	- `QuoteRequestRepository`에 삭제된 요청을 쿼리하는 메소드 추가.
	- `TotalQuoteRequestRepository`에 `QuoteRequest`를 삭제하는 메소드 추가.
	- `QuoteRequestScheduledService` 클래스 추가 및 매일 삭제 요청을 처리하는 메소드 추가.
	- `DogScheduledService`에서 기본 개 프로필 이미지 삭제 방지 로직 추가.

- **버그 수정**
	- `ChatScheduledService`에서 삭제된 채팅 메시지와 관련된 파일을 S3에서 삭제하도록 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->