### PR TITLE
Fix: 배포환경으로 application-dev.properties 수정

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -57,8 +57,8 @@ spring.security.oauth2.client.registration.kakao.client-name=kakao
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
 
-#spring.security.oauth2.client.registration.kakao.redirect-uri=https://beautymeongdang.vercel.app/login/oauth2/code/kakao
-spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:5173/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri=https://beautymeongdang.vercel.app/login/oauth2/code/kakao
+#spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:5173/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.scope=profile_nickname,account_email,profile_image
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
@@ -74,8 +74,8 @@ spring.security.oauth2.client.registration.google.client-name=google
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 
-#spring.security.oauth2.client.registration.google.redirect-uri=https://beautymeongdang.vercel.app/login/oauth2/code/google
-spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:5173/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.redirect-uri=https://beautymeongdang.vercel.app/login/oauth2/code/google
+#spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:5173/login/oauth2/code/google
 spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.google.scope=profile,email
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
	- 카카오 및 구글 OAuth2 클라이언트 등록을 위한 리디렉션 URI가 로컬호스트에서 프로덕션 URL로 업데이트되었습니다. 
	- 카카오: `https://beautymeongdang.vercel.app/login/oauth2/code/kakao`
	- 구글: `https://beautymeongdang.vercel.app/login/oauth2/code/google`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->